### PR TITLE
Correctly calculate defence strength and round it down

### DIFF
--- a/apps/api/src/models/player.ts
+++ b/apps/api/src/models/player.ts
@@ -85,17 +85,17 @@ export default class PlayerModel {
   }
 
   async calculateDefenceStrength(): Promise<number> {
-    const defence = this.units.reduce(
+    let defence = this.units.reduce(
       (acc, unit) => acc + unit.calculateDefenceStrength(),
       0,
     );
     if (this.race === 'elf' || this.race === 'goblin') {
       // Elves and Goblins get a 5% bonus to defence strength
-      return defence * 1.05;
+      defence *= 1.05;
     }
     if (this.class === 'cleric') {
       // Clerics get a 5% bonus to defence strength
-      return defence * 1.05;
+      defence *= 1.05;
     }
     return Math.floor(defence);
   }


### PR DESCRIPTION
Issue was caused by the `calculateDefenceStrength` method on the player model. It was returning early rather than updating the defence number. This lead to a float being returned rather than passing through the other checks and returning at the end.

This also means that the defence stats weren't correctly being counted.

---

The test replicated an exact scenario causing the crash on production.