### PR TITLE
Fix local build failures for react apps.

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -29,3 +29,5 @@ jobs:
         SERVER_HOST: ${{ secrets.SERVER_HOST }}
         SERVER_USER: ${{ secrets.SERVER_USER }}
         SERVER_PASS: ${{ secrets.SERVER_PASS }}
+        VITE_GAME_APP_URL: ${{ secrets.GAME_APP_URL }}
+        VITE_GAME_API_URL: ${{ secrets.GAME_API_URL }}

--- a/apps/placeholder-site/src/environments/environment.production.ts
+++ b/apps/placeholder-site/src/environments/environment.production.ts
@@ -1,3 +1,0 @@
-export default {
-  gameAppUrl: 'https://play.darkthronereborn.com',
-};

--- a/apps/placeholder-site/src/environments/environment.ts
+++ b/apps/placeholder-site/src/environments/environment.ts
@@ -1,3 +1,3 @@
 export default {
-  gameAppUrl: 'http://localhost:4200',
+  gameAppUrl: import.meta.env.VITE_GAME_APP_URL || 'http://localhost:4200',
 };

--- a/apps/placeholder-site/vite.config.ts
+++ b/apps/placeholder-site/vite.config.ts
@@ -1,5 +1,4 @@
 /// <reference types="vitest" />
-import { replaceFiles } from '@nx/vite/plugins/rollup-replace-files.plugin';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
@@ -16,7 +15,7 @@ export default defineConfig({
   cacheDir: '../../node_modules/.vite/placeholder-site',
 
   server: {
-    port: 4200,
+    port: 4201,
     host: 'localhost',
   },
 
@@ -25,16 +24,7 @@ export default defineConfig({
     host: 'localhost',
   },
 
-  plugins: [
-    replaceFiles([
-      {
-        replace: 'apps/placeholder-site/src/environments/environment.ts',
-        with: 'apps/placeholder-site/src/environments/environment.production.ts',
-      },
-    ]),
-    react(),
-    nxViteTsPaths(),
-  ],
+  plugins: [react(), nxViteTsPaths()],
 
   // Uncomment this if you are using workers.
   // worker: {

--- a/apps/web-app/src/environments/environment.production.ts
+++ b/apps/web-app/src/environments/environment.production.ts
@@ -1,3 +1,0 @@
-export default {
-  gameAPI: 'https://api.darkthronereborn.com',
-};

--- a/apps/web-app/src/environments/environment.ts
+++ b/apps/web-app/src/environments/environment.ts
@@ -1,3 +1,3 @@
 export default {
-  gameAPI: 'http://localhost:3000',
+  gameAPI: import.meta.env.VITE_GAME_API_URL || 'http://localhost:3000',
 };

--- a/apps/web-app/vite.config.ts
+++ b/apps/web-app/vite.config.ts
@@ -1,5 +1,4 @@
 /// <reference types="vitest" />
-import { replaceFiles } from '@nx/vite/plugins/rollup-replace-files.plugin';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
@@ -25,16 +24,7 @@ export default defineConfig({
     host: 'localhost',
   },
 
-  plugins: [
-    replaceFiles([
-      {
-        replace: 'apps/web-app/src/environments/environment.ts',
-        with: 'apps/web-app/src/environments/environment.production.ts',
-      },
-    ]),
-    react(),
-    nxViteTsPaths(),
-  ],
+  plugins: [react(), nxViteTsPaths()],
 
   // Uncomment this if you are using workers.
   // worker: {


### PR DESCRIPTION
Prior to my upgrade of NX to V18 we had to use file replacement for the production config of web apps. This sucked. With v18 they added proper support for Vite and environment variables, they also deprecated the file replacement approach.

This change replaced the file replacement approach with the new (and objectively better) env var approach.

> Note: When I did the migration for my work a few weeks ago this didn't come up as we are using Webpack, not Vite

---