### PR TITLE
Fix next turn in timing

### DIFF
--- a/apps/web-app/src/components/layout/headerBar.tsx
+++ b/apps/web-app/src/components/layout/headerBar.tsx
@@ -42,18 +42,19 @@ export default function HeaderBar(props: HeaderBarProps) {
   function calculateTimeRemaining(serverTime: Date) {
     const minutes = serverTime.getMinutes();
     const seconds = serverTime.getSeconds();
-    let minutesRemaining;
 
-    if (minutes < 30) {
-      minutesRemaining = 30 - minutes;
-    } else if (minutes === 30) {
-      minutesRemaining = 30;
-    } else {
-      minutesRemaining = 60 - minutes;
-    }
+    const halfHourInSeconds = 60 * 30;
 
-    const secondsRemaining = 60 - seconds;
-    return { minutes: minutesRemaining, seconds: secondsRemaining };
+    const timeInSeconds = minutes * 60 + seconds;
+    const timeSinceHourOrHalfHourInSeconds =
+    timeInSeconds % halfHourInSeconds;
+    const timeToHourOrHalfHourInSeconds =
+      halfHourInSeconds - timeSinceHourOrHalfHourInSeconds;
+
+    const minutesRemaining = Math.floor(timeToHourOrHalfHourInSeconds / 60);
+    const remainingSeconds = timeToHourOrHalfHourInSeconds % 60;
+
+    return `${String(minutesRemaining).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
   }
 
   async function handleSwitchPlayer() {
@@ -88,7 +89,7 @@ export default function HeaderBar(props: HeaderBarProps) {
           {timeRemaining ? (
             <div>
               Next Turn In:{' '}
-              <span className="text-white font-bold">{`${timeRemaining.minutes}:${timeRemaining.seconds < 10 ? '0' : ''}${timeRemaining.seconds}`}</span>
+              <span className="text-white font-bold">{timeRemaining}</span>
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
https://github.com/MattGibney/DarkThrone/assets/13131778/804671d5-8931-477d-a615-0888026beac8


I'm not happy with the setInterval inside the useEffect, it sometimes runs two intervals in parallel, couldn't replicate again when I tried, but I don't have a good idea about how we can improve it yet.

The timing function logic is now simpler, tried to use suggestive variable names, I initially used a one-liner and comments, something like:
```ts
    const remainingSeconds = (60*30)-((minutes*60+seconds)%(60*30))
```