### PR TITLE
Attack List Pagination

### DIFF
--- a/apps/api/src/controllers/player.ts
+++ b/apps/api/src/controllers/player.ts
@@ -2,14 +2,14 @@ import { Request, Response } from 'express';
 
 export default {
   GET_fetchAllPlayers: async (req: Request, res: Response) => {
-    const { page, size } = req.query;
+    const { page, pageSize } = req.query;
     const pageNumber = parseInt(page as string) || 1;
-    const pageSize = parseInt(size as string) || 100;
+    const pageSizeNumber = parseInt(pageSize as string) || 100;
 
     const paginator = await req.ctx.modelFactory.player.fetchAllPaginated(
       req.ctx,
       pageNumber,
-      pageSize,
+      pageSizeNumber,
     );
 
     res.status(200).json(await paginator.serialise());

--- a/apps/api/src/controllers/player.ts
+++ b/apps/api/src/controllers/player.ts
@@ -2,15 +2,17 @@ import { Request, Response } from 'express';
 
 export default {
   GET_fetchAllPlayers: async (req: Request, res: Response) => {
-    const players = await req.ctx.modelFactory.player.fetchAll(req.ctx);
+    const { page, size } = req.query;
+    const pageNumber = parseInt(page as string) || 1;
+    const pageSize = parseInt(size as string) || 100;
 
-    res
-      .status(200)
-      .json(
-        await Promise.all(
-          players.map(async (player) => await player.serialise()),
-        ),
-      );
+    const paginator = await req.ctx.modelFactory.player.fetchAllPaginated(
+      req.ctx,
+      pageNumber,
+      pageSize,
+    );
+
+    res.status(200).json(await paginator.serialise());
   },
 
   GET_fetchPlayersForUser: async (req: Request, res: Response) => {

--- a/apps/api/src/controllers/player.ts
+++ b/apps/api/src/controllers/player.ts
@@ -3,8 +3,11 @@ import { Request, Response } from 'express';
 export default {
   GET_fetchAllPlayers: async (req: Request, res: Response) => {
     const { page, pageSize } = req.query;
-    const pageNumber = parseInt(page as string) || 1;
-    const pageSizeNumber = parseInt(pageSize as string) || 100;
+    const pageNumber = Math.max(parseInt(page as string), 1);
+    const pageSizeNumber = Math.max(
+      1,
+      Math.min(200, parseInt(pageSize as string)),
+    );
 
     const paginator = await req.ctx.modelFactory.player.fetchAllPaginated(
       req.ctx,

--- a/apps/api/src/daos/player.ts
+++ b/apps/api/src/daos/player.ts
@@ -67,12 +67,12 @@ export default class PlayerDao {
       paginator.dataRows = rows;
 
       // All rows have the same total_count, so just pick the first one
-      paginator.totalCount = rows.length > 0 ? rows[0].total_count : 0;
+      paginator.totalItemCount = rows.length > 0 ? rows[0].total_count : 0;
 
       return;
     } catch (error) {
       logger.error(error, 'DAO: Failed to fetch all players');
-      paginator.totalCount = 0;
+      paginator.totalItemCount = 0;
       return;
     }
   }

--- a/apps/api/src/daos/player.ts
+++ b/apps/api/src/daos/player.ts
@@ -2,6 +2,8 @@ import { PlayerClass, PlayerRace } from '@darkthrone/interfaces';
 import { Knex } from 'knex';
 import { Logger } from 'pino';
 import { ulid } from 'ulid';
+import { Paginator } from '../lib/paginator';
+import PlayerModel from '../models/player';
 
 export type PlayerRow = {
   id: string;
@@ -45,6 +47,33 @@ export default class PlayerDao {
     } catch (error) {
       logger.error(error, 'DAO: Failed to fetch all players');
       return [];
+    }
+  }
+
+  async fetchAllPaginated(
+    logger: Logger,
+    paginator: Paginator<PlayerRow, PlayerModel>,
+  ): Promise<undefined> {
+    try {
+      const rows = await this.database('players')
+        .select(
+          'players.*',
+          this.database.raw('COUNT(*) OVER() AS total_count'),
+        )
+        .orderBy('overall_rank', 'ASC')
+        .limit(paginator.pageSize)
+        .offset((paginator.page - 1) * paginator.pageSize);
+
+      paginator.dataRows = rows;
+
+      // All rows have the same total_count, so just pick the first one
+      paginator.totalCount = rows.length > 0 ? rows[0].total_count : 0;
+
+      return;
+    } catch (error) {
+      logger.error(error, 'DAO: Failed to fetch all players');
+      paginator.totalCount = 0;
+      return;
     }
   }
 

--- a/apps/api/src/lib/paginator.ts
+++ b/apps/api/src/lib/paginator.ts
@@ -1,0 +1,34 @@
+interface Serialisable {
+  serialise(): Promise<object>;
+  id: string;
+}
+
+export class Paginator<R, I extends Serialisable> {
+  public dataRows: R[];
+  public items: I[];
+  public totalCount = 0;
+  public page: number;
+  public pageSize: number;
+  private rowObject: R;
+  private itemObject: I;
+
+  constructor(page = 1, pageSize = 25) {
+    this.page = page;
+    this.pageSize = pageSize;
+    this.items = [];
+    this.dataRows = [];
+  }
+
+  async serialise(): Promise<object> {
+    return {
+      items: await Promise.all(
+        this.items.map(async (item) => await item.serialise()),
+      ),
+      meta: {
+        totalCount: this.totalCount,
+        page: this.page,
+        pageSize: this.pageSize,
+      },
+    };
+  }
+}

--- a/apps/api/src/lib/paginator.ts
+++ b/apps/api/src/lib/paginator.ts
@@ -6,7 +6,7 @@ interface Serialisable {
 export class Paginator<R, I extends Serialisable> {
   public dataRows: R[];
   public items: I[];
-  public totalCount = 0;
+  public totalItemCount = 0;
   public page: number;
   public pageSize: number;
   private rowObject: R;
@@ -25,7 +25,8 @@ export class Paginator<R, I extends Serialisable> {
         this.items.map(async (item) => await item.serialise()),
       ),
       meta: {
-        totalCount: this.totalCount,
+        totalItemCount: this.totalItemCount,
+        totalPageCount: Math.ceil(this.totalItemCount / this.pageSize),
         page: this.page,
         pageSize: this.pageSize,
       },

--- a/apps/web-app/src/libs/pagination.ts
+++ b/apps/web-app/src/libs/pagination.ts
@@ -10,7 +10,11 @@ interface PaginatorProps<R> {
   fetchForPage: (pageNumber: number) => Promise<
     | {
         items: R[];
-        meta: { totalCount: number; pageSize: number };
+        meta: {
+          totalItemCount: number;
+          totalPageCount: number;
+          pageSize: number;
+        };
       }
     | undefined
   >;
@@ -48,25 +52,12 @@ export function Paginator<T>(props: PaginatorProps<T>) {
       }
 
       setData(fetched.items);
-      const numberOfPages = calculateNumberOfPages(
-        fetched.meta.totalCount,
-        fetched.meta.pageSize,
-      );
-      setTotalPages(numberOfPages);
-      setTotalItems(fetched.meta.totalCount);
+      setTotalPages(fetched.meta.totalPageCount);
+      setTotalItems(fetched.meta.totalItemCount);
     };
 
     fetchData();
   }, [currentPageNumber, fetchForPage, setPage]);
 
   return { setPage, totalPages, totalItems, data, setData };
-}
-
-export function calculateNumberOfPages(
-  totalCount: number | undefined,
-  pageSize: number | undefined,
-): number {
-  if (!totalCount || !pageSize) return 0;
-  const numberOfPages = Math.ceil(totalCount / pageSize);
-  return numberOfPages;
 }

--- a/apps/web-app/src/libs/pagination.ts
+++ b/apps/web-app/src/libs/pagination.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useState } from 'react';
+import { NavigateFunction } from 'react-router-dom';
+
+interface PaginatorProps<R> {
+  dataUpdate?: Date;
+  id?: string;
+  paginationRoute: string;
+  navigate: NavigateFunction;
+  currentPageNumber: number;
+  fetchForPage: (pageNumber: number) => Promise<
+    | {
+        items: R[];
+        meta: { totalCount: number; pageSize: number };
+      }
+    | undefined
+  >;
+}
+export function Paginator<T>(props: PaginatorProps<T>) {
+  const [data, setData] = useState<T[] | undefined>(undefined);
+  const [totalPages, setTotalPages] = useState<number>(0);
+  const [totalItems, setTotalItems] = useState<number>(0);
+
+  const { currentPageNumber, fetchForPage, navigate, paginationRoute } = props;
+
+  const setPage = useCallback(
+    (desiredPageNumber: number) => {
+      if (desiredPageNumber < 1) {
+        desiredPageNumber = 1;
+      }
+
+      if (desiredPageNumber > totalPages) {
+        desiredPageNumber = totalPages;
+      }
+
+      // Sets Page Number
+      navigate(`${paginationRoute}?page=${desiredPageNumber}`);
+    },
+    [navigate, paginationRoute, totalPages],
+  );
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const fetched = await fetchForPage(currentPageNumber);
+      if (!fetched) return;
+
+      if (fetched.items.length === 0 && currentPageNumber > 1) {
+        setPage(1);
+      }
+
+      setData(fetched.items);
+      const numberOfPages = calculateNumberOfPages(
+        fetched.meta.totalCount,
+        fetched.meta.pageSize,
+      );
+      setTotalPages(numberOfPages);
+      setTotalItems(fetched.meta.totalCount);
+    };
+
+    fetchData();
+  }, [currentPageNumber, fetchForPage, setPage]);
+
+  return { setPage, totalPages, totalItems, data, setData };
+}
+
+export function calculateNumberOfPages(
+  totalCount: number | undefined,
+  pageSize: number | undefined,
+): number {
+  if (!totalCount || !pageSize) return 0;
+  const numberOfPages = Math.ceil(totalCount / pageSize);
+  return numberOfPages;
+}

--- a/apps/web-app/src/pages/main/battle/attack/list.tsx
+++ b/apps/web-app/src/pages/main/battle/attack/list.tsx
@@ -37,7 +37,11 @@ export default function AttackListPage(props: AttackListPageProps) {
     [props.client.players],
   );
 
-  const { setPage, totalItems, data } = Paginator<PlayerObject>({
+  const {
+    setPage,
+    totalItems,
+    data: players,
+  } = Paginator<PlayerObject>({
     paginationRoute: '/attack',
     navigate,
     currentPageNumber,
@@ -52,7 +56,7 @@ export default function AttackListPage(props: AttackListPageProps) {
     [setPage, setSearchParams],
   );
 
-  if (!data) {
+  if (!players) {
     return null;
   }
 
@@ -99,7 +103,7 @@ export default function AttackListPage(props: AttackListPageProps) {
                   </tr>
                 </thead>
                 <tbody>
-                  {data.map((player, playerIdx) => (
+                  {players.map((player, playerIdx) => (
                     <tr
                       key={playerIdx}
                       className="even:bg-zinc-800/50 cursor-pointer"

--- a/libs/client-library/src/controllers/players.ts
+++ b/libs/client-library/src/controllers/players.ts
@@ -31,7 +31,6 @@ export default class PlayersController {
       return { status: 'ok', data: response.data };
     } catch (err: unknown) {
       const axiosError = err as AxiosError;
-      console.log(err);
 
       return { status: 'fail', data: axiosError.response?.data as APIError[] };
     }

--- a/libs/client-library/src/index.ts
+++ b/libs/client-library/src/index.ts
@@ -20,7 +20,8 @@ export type APIError = {
 export type PaginatedResponse<T> = {
   items: T[];
   meta: {
-    totalCount: number;
+    totalItemCount: number;
+    totalPageCount: number;
     page: number;
     pageSize: number;
   };

--- a/libs/client-library/src/index.ts
+++ b/libs/client-library/src/index.ts
@@ -17,6 +17,15 @@ export type APIError = {
   detail?: string;
 };
 
+export type PaginatedResponse<T> = {
+  items: T[];
+  meta: {
+    totalCount: number;
+    page: number;
+    pageSize: number;
+  };
+};
+
 export type APIResponse<S, T> = {
   status: S;
   data: T;


### PR DESCRIPTION
This change adds pagination to the attack list. The big point of note here is the pagination logic in both the API and on the React app are re-usable. Additional resources that need to be paginated in the future can make use of this same approach with minimal effort. 🙌🏻 

Also note that I kept the methods for fetching ALL players. This is useful for the scripts that process attack turns etc. They can be updated later to support pagination, I just wanted to avoid this PR getting too large :)

---

## Demo

https://github.com/MattGibney/DarkThrone/assets/48440667/b2414857-8b62-483a-ac8f-0f7ef0f17674

This demo has page size set to 2. It's actually specified as 100 in code.
