### PR TITLE
Bake the commit hash has into the built applications.

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -79,7 +79,7 @@ const application = (
   });
 
   app.use(async (req, res, next) => {
-    if (!req.headers.authorization) return;
+    if (!req.headers.authorization) return next();
 
     const [type, token] = req.headers.authorization.split(' ');
     if (!token) return next();
@@ -117,7 +117,7 @@ const application = (
   });
 
   app.get('/healthcheck', (req, res) => {
-    res.send({ message: 'OK' });
+    res.send({ message: 'OK', commitHash: '__COMMIT_HASH__' });
   });
 
   app.use(router);

--- a/apps/web-app/src/components/layout/footer.tsx
+++ b/apps/web-app/src/components/layout/footer.tsx
@@ -1,10 +1,9 @@
 export default function Footer() {
   return (
-    <footer className="mx-auto max-w-7xl px-6 py-12 flex items-center justify-center lg:px-8">
-      <div className="mt-8 md:mt-0">
-        <p className="text-center text-xs leading-5 text-zinc-500">
-          &copy; 2024 DarkThrone Reborn
-        </p>
+    <footer className="mx-auto max-w-7xl px-6 py-12 lg:px-8">
+      <div className="mt-8 md:mt-0 flex justify-between text-xs text-zinc-500">
+        <p>&copy; 2024 DarkThrone Reborn</p>
+        <p className="text-zinc-700">Version: __COMMIT_HASH__</p>
       </div>
     </footer>
   );

--- a/apps/web-app/src/pages/auth/login.tsx
+++ b/apps/web-app/src/pages/auth/login.tsx
@@ -8,6 +8,7 @@ import {
 } from '@darkthrone/react-components';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import Footer from '../../components/layout/footer';
 
 interface LoginPageProps {
   client: DarkThroneClient;
@@ -101,7 +102,7 @@ export default function LoginPage(props: LoginPageProps) {
           </form>
         </div>
 
-        <p className="mt-10 text-center text-sm text-zinc-500">
+        <p className="my-10 text-center text-sm text-zinc-500">
           Not a member?{' '}
           <Link
             to="/register"
@@ -110,6 +111,8 @@ export default function LoginPage(props: LoginPageProps) {
             Create an account now
           </Link>
         </p>
+
+        <Footer />
       </div>
     </main>
   );

--- a/apps/web-app/src/pages/auth/register.tsx
+++ b/apps/web-app/src/pages/auth/register.tsx
@@ -2,6 +2,7 @@ import DarkThroneClient from '@darkthrone/client-library';
 import { Alert, Button, InputField, Logo } from '@darkthrone/react-components';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import Footer from '../../components/layout/footer';
 
 interface RegisterPageProps {
   client: DarkThroneClient;
@@ -104,7 +105,7 @@ export default function RegisterPage(props: RegisterPageProps) {
           </form>
         </div>
 
-        <p className="mt-10 text-center text-sm text-zinc-500">
+        <p className="my-10 text-center text-sm text-zinc-500">
           Already a member?{' '}
           <Link
             to="/login"
@@ -113,6 +114,8 @@ export default function RegisterPage(props: RegisterPageProps) {
             Login now
           </Link>
         </p>
+
+        <Footer />
       </div>
     </main>
   );


### PR DESCRIPTION
There are possibly nicer ways to do this. I originally was going to create a build info json file and have the application read that when it executes. However that only works for the API. The web apps need this baked in directly.

I could have achieved this with environment variables, however I'm not a big fan of that approach for this sort of thing.

Considering it's static information as far as the built application goes and it's not something that should ever change, unless we have a new build. I felt that this was the strongest option.