### PR TITLE
fix(api): return after missing login params

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -1,0 +1,4 @@
+# API Notes
+
+- `apps/api/src/app.ts` creates a fresh `ModelFactory` per request, so acceptance tests cannot inject model behavior through `makeApplication`.
+- When an API acceptance test needs to verify model-layer calls from a controller, spy on the relevant model class static (for example `jest.spyOn(UserModel, 'fetchByEmail')`) and keep DAO stubs in `makeApplication` focused on lower-level data access.

--- a/apps/api/src/controllers/auth.ts
+++ b/apps/api/src/controllers/auth.ts
@@ -25,6 +25,7 @@ export default {
 
     if (!email || !password) {
       res.status(400).send({ errors: ['auth.login.missingParams'] });
+      return;
     }
 
     const user = await req.ctx.modelFactory.user.fetchByEmail(req.ctx, email);

--- a/apps/api/test/acceptance/auth/POST_login.spec.ts
+++ b/apps/api/test/acceptance/auth/POST_login.spec.ts
@@ -1,8 +1,13 @@
 import request from 'supertest';
 import makeApplication from '../helpers/makeApplication';
 import DaoFactory from '../../../src/daoFactory';
+import UserModel from '../../../src/models/user';
 
 describe('POST_login', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should return 400 if email is missing', async () => {
     const { application } = makeApplication({});
 
@@ -22,6 +27,31 @@ describe('POST_login', () => {
     expect(res.status).toBe(400);
     expect(res.body.errors).toContain('auth.login.missingParams');
   });
+
+  it.each([
+    {
+      caseName: 'missing email',
+      payload: { password: 'password' },
+    },
+    {
+      caseName: 'missing password',
+      payload: { email: 'test@example.com' },
+    },
+  ])(
+    'should not fetch a user when login params are invalid ($caseName)',
+    async ({ payload }) => {
+      const fetchByEmailSpy = jest
+        .spyOn(UserModel, 'fetchByEmail')
+        .mockResolvedValue(null);
+      const { application } = makeApplication({});
+
+      const res = await request(application).post('/auth/login').send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.errors).toContain('auth.login.missingParams');
+      expect(fetchByEmailSpy).not.toHaveBeenCalled();
+    },
+  );
 
   it('should return 401 if user does not exist', async () => {
     const { application } = makeApplication({


### PR DESCRIPTION
## Summary
- return immediately after `auth.login.missingParams` is sent in `POST /auth/login`
- add acceptance coverage proving malformed login requests do not trigger `UserModel.fetchByEmail`
- document the API acceptance-test model spying pattern in `apps/api/AGENTS.md`

## Testing
- npx nx test api --runInBand

Closes #104