### PR TITLE
Fix overview XP progress calculation

### DIFF
--- a/apps/web-app/AGENTS.md
+++ b/apps/web-app/AGENTS.md
@@ -3,3 +3,4 @@
 - Authenticated player state in `DarkThroneClient` is a snapshot loaded from `/auth/current-user`; turn-based resources like `gold` and `attackTurns` will look stale unless the app re-fetches after the half-hour turn boundary or when the window regains focus.
 - Shared turn countdown and turn-refresh math lives in `apps/web-app/src/libs/turnTiming.ts`. Reuse it instead of duplicating half-hour calculations in components.
 - `App` owns global player refresh behavior. Prefer emitting `playerUpdate` after player-mutating actions and let the app shell re-fetch the canonical player snapshot.
+- Overview XP progress should be calculated within the current level band. Reuse `apps/web-app/src/libs/experienceProgress.ts` instead of dividing lifetime XP by the next threshold in UI components.

--- a/apps/web-app/jest.config.ts
+++ b/apps/web-app/jest.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 export default {
   displayName: 'web-app',
   preset: '../../jest.preset.js',

--- a/apps/web-app/src/libs/experienceProgress.spec.ts
+++ b/apps/web-app/src/libs/experienceProgress.spec.ts
@@ -1,0 +1,36 @@
+import { getExperienceProgress } from './experienceProgress';
+
+describe('experienceProgress', () => {
+  it('uses the full level one band for progress', () => {
+    expect(getExperienceProgress(1, 1_000)).toEqual({
+      previousLevelXP: 0,
+      nextLevelXP: 4_000,
+      xpIntoLevel: 1_000,
+      xpRequiredForLevel: 4_000,
+      xpRemaining: 3_000,
+      xpProgress: 25,
+    });
+  });
+
+  it('measures higher levels from the previous threshold instead of lifetime XP', () => {
+    expect(getExperienceProgress(2, 5_000)).toEqual({
+      previousLevelXP: 4_000,
+      nextLevelXP: 8_000,
+      xpIntoLevel: 1_000,
+      xpRequiredForLevel: 4_000,
+      xpRemaining: 3_000,
+      xpProgress: 25,
+    });
+  });
+
+  it('caps progress and remaining XP at the level threshold', () => {
+    expect(getExperienceProgress(2, 8_000)).toEqual({
+      previousLevelXP: 4_000,
+      nextLevelXP: 8_000,
+      xpIntoLevel: 4_000,
+      xpRequiredForLevel: 4_000,
+      xpRemaining: 0,
+      xpProgress: 100,
+    });
+  });
+});

--- a/apps/web-app/src/libs/experienceProgress.ts
+++ b/apps/web-app/src/libs/experienceProgress.ts
@@ -1,0 +1,38 @@
+import { levelXPArray } from '@darkthrone/game-data';
+
+export interface ExperienceProgress {
+  previousLevelXP: number;
+  nextLevelXP: number;
+  xpIntoLevel: number;
+  xpRequiredForLevel: number;
+  xpRemaining: number;
+  xpProgress: number;
+}
+
+export function getExperienceProgress(
+  level: number,
+  experience: number,
+): ExperienceProgress {
+  const safeLevel = Math.max(1, level);
+  const lastLevelIndex = levelXPArray.length - 1;
+  const nextLevelIndex = Math.min(safeLevel - 1, lastLevelIndex);
+  const previousLevelIndex = Math.max(0, nextLevelIndex - 1);
+  const nextLevelXP = levelXPArray[nextLevelIndex] ?? 0;
+  const previousLevelXP = safeLevel > 1 ? levelXPArray[previousLevelIndex] : 0;
+  const xpRequiredForLevel = Math.max(1, nextLevelXP - previousLevelXP);
+  const xpIntoLevel = Math.min(
+    xpRequiredForLevel,
+    Math.max(0, experience - previousLevelXP),
+  );
+
+  return {
+    previousLevelXP,
+    nextLevelXP,
+    xpIntoLevel,
+    xpRequiredForLevel,
+    xpRemaining: Math.max(0, nextLevelXP - experience),
+    xpProgress: nextLevelXP
+      ? Math.min(100, (xpIntoLevel / xpRequiredForLevel) * 100)
+      : 0,
+  };
+}

--- a/apps/web-app/src/pages/main/home/overview.tsx
+++ b/apps/web-app/src/pages/main/home/overview.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import DarkThroneClient from '@darkthrone/client-library';
-import { levelXPArray, UnitTypes } from '@darkthrone/game-data';
+import { UnitTypes } from '@darkthrone/game-data';
 import { UnitType } from '@darkthrone/interfaces';
 import {
   Card,
@@ -11,6 +11,7 @@ import {
 } from '@darkthrone/shadcnui/card';
 import { Avatar } from '../../../components/avatar';
 import Stat from '../../../components/home/Stat';
+import { getExperienceProgress } from '../../../libs/experienceProgress';
 import { formatTimeUntilNextTurn } from '../../../libs/turnTiming';
 
 interface OverviewPageProps {
@@ -49,13 +50,8 @@ export default function OverviewPage(props: OverviewPageProps) {
     (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
   )[0];
 
-  const currentLevelIndex = Math.max(0, player.level - 1);
-  const nextLevelXP =
-    levelXPArray[currentLevelIndex] ?? levelXPArray[levelXPArray.length - 1];
-  const xpRemaining = Math.max(0, nextLevelXP - player.experience);
-  const xpProgress = nextLevelXP
-    ? Math.min(100, (player.experience / nextLevelXP) * 100)
-    : 0;
+  const { xpIntoLevel, xpProgress, xpRemaining, xpRequiredForLevel } =
+    getExperienceProgress(player.level, player.experience);
 
   const [currentTime, setCurrentTime] = useState(
     props.client.serverTime ? new Date(props.client.serverTime) : undefined,
@@ -176,8 +172,8 @@ export default function OverviewPage(props: OverviewPageProps) {
             <div className="flex items-center justify-between text-sm text-card-foreground/60">
               <span>Experience</span>
               <span>
-                {formatNumber.format(player.experience)} /{' '}
-                {formatNumber.format(nextLevelXP)}
+                {formatNumber.format(xpIntoLevel)} /{' '}
+                {formatNumber.format(xpRequiredForLevel)}
               </span>
             </div>
             <div className="mt-3 h-2 overflow-hidden rounded-full bg-card-foreground/10">


### PR DESCRIPTION
## Summary
- calculate overview XP progress from the current level band instead of lifetime XP
- extract the XP math into a dedicated helper with Jest coverage for level 1, higher levels, and threshold boundaries
- remove an unused `eslint-disable` in the web-app Jest config so `nx lint web-app` passes cleanly

## Testing
- `npx nx lint web-app`
- `npx nx test web-app --runInBand`

Closes #105