### PR TITLE
Fix failed attacks consuming turns and refreshing state

### DIFF
--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -1,0 +1,4 @@
+# API Notes
+
+- `PlayerModel.attackPlayer` must always deduct the requested `attackTurns` for any completed attack. Victory only changes gold transfer and attacker XP.
+- Persist attacker and defender state before returning the attack result so the web app's follow-up `/auth/current-user` refresh sees the updated snapshot immediately.

--- a/apps/api/src/models/player.ts
+++ b/apps/api/src/models/player.ts
@@ -360,10 +360,13 @@ export default class PlayerModel {
       getRandomNumber(500, 1500) * (0.1 * attackTurns),
     );
 
+    // Completed attacks always spend the requested turns, regardless of outcome.
+    this.attackTurns -= attackTurns;
+
     if (!isVictor) {
       // Grant XP to the defender
       targetPlayer.experience += victorExperience;
-      await targetPlayer.save();
+      await Promise.all([this.save(), targetPlayer.save()]);
 
       // Create War History
       return await this.ctx.modelFactory.warHistory.create(this.ctx, {
@@ -392,11 +395,7 @@ export default class PlayerModel {
     // Grant XP to the attacker
     this.experience += victorExperience;
 
-    // Subtract attack Turns
-    this.attackTurns -= attackTurns;
-
-    this.save();
-    targetPlayer.save();
+    await Promise.all([this.save(), targetPlayer.save()]);
 
     return await this.ctx.modelFactory.warHistory.create(this.ctx, {
       id: warHistoryID,

--- a/apps/api/test/unit/models/player.spec.ts
+++ b/apps/api/test/unit/models/player.spec.ts
@@ -314,9 +314,12 @@ describe('Model: Player', () => {
   describe('attackPlayer', () => {
     it('should correctly record war history for a successful attack', async () => {
       const attackerPlayerRow = {
+        ...mockPlayerRow,
         id: 'PLR-01HQP5D6HM1XS3MNAQXZAWP61K',
         race: 'elf',
-        class: 'theif',
+        class: 'thief',
+        attack_turns: 10,
+        experience: 0,
         gold: 100,
       } as unknown as PlayerRow;
       const attackerUnits = [
@@ -328,9 +331,12 @@ describe('Model: Player', () => {
       ] as unknown as PlayerUnitsModel[];
 
       const defenderPlayerRow = {
+        ...mockPlayerRow,
         id: 'PLR-01HQP5DE1ZC99QTZR4AVV0MS7R',
         race: 'goblin',
         class: 'cleric',
+        attack_turns: 6,
+        experience: 0,
         gold: 100,
       } as unknown as PlayerRow;
       const defenderUnits = [
@@ -341,15 +347,11 @@ describe('Model: Player', () => {
         } as unknown as PlayerUnitsModel,
       ] as unknown as PlayerUnitsModel[];
 
+      const warHistoryCreate = jest.fn().mockResolvedValue({});
       const mockCTX = {
-        daoFactory: {
-          player: {
-            update: jest.fn().mockResolvedValue(attackerPlayerRow),
-          },
-        },
         modelFactory: {
           warHistory: {
-            create: jest.fn().mockResolvedValue({}),
+            create: warHistoryCreate,
           },
         },
       } as unknown as Context;
@@ -368,24 +370,110 @@ describe('Model: Player', () => {
         [],
       );
 
+      attacker.save = jest.fn().mockResolvedValue(undefined);
+      defender.save = jest.fn().mockResolvedValue(undefined);
+
       await attacker.attackPlayer(defender, 10);
 
-      expect(mockCTX.modelFactory.warHistory.create).toHaveBeenCalledWith(
-        mockCTX,
+      expect(attacker.attackTurns).toEqual(0);
+      expect(attacker.save).toHaveBeenCalledTimes(1);
+      expect(defender.save).toHaveBeenCalledTimes(1);
+      expect(warHistoryCreate).toHaveBeenCalledWith(mockCTX, {
+        id: expect.any(String),
+        attacker_id: 'PLR-01HQP5D6HM1XS3MNAQXZAWP61K',
+        defender_id: 'PLR-01HQP5DE1ZC99QTZR4AVV0MS7R',
+        attack_turns_used: 10,
+        is_attacker_victor: true,
+        attacker_strength: 18,
+        defender_strength: 3,
+        gold_stolen: expect.any(Number),
+        created_at: expect.any(Date),
+        attacker_experience: expect.any(Number),
+        defender_experience: 0,
+      });
+    });
+
+    it('should spend attack turns and refresh persistence for a failed attack', async () => {
+      const attackerPlayerRow = {
+        ...mockPlayerRow,
+        id: 'PLR-01JNY92QZMGD2B30S6PP0BBQ31',
+        race: 'human',
+        class: 'fighter',
+        attack_turns: 10,
+        experience: 0,
+        gold: 100,
+      } as unknown as PlayerRow;
+      const attackerUnits = [
         {
-          id: expect.any(String),
-          attacker_id: 'PLR-01HQP5D6HM1XS3MNAQXZAWP61K',
-          defender_id: 'PLR-01HQP5DE1ZC99QTZR4AVV0MS7R',
-          attack_turns_used: 10,
-          is_attacker_victor: true,
-          attacker_strength: 18,
-          defender_strength: 3,
-          gold_stolen: expect.any(Number),
-          created_at: expect.any(Date),
-          attacker_experience: expect.any(Number),
-          defender_experience: 0,
+          unitType: 'soldier_1',
+          quantity: 1,
+          calculateAttackStrength: jest.fn().mockReturnValue(4),
+        } as unknown as PlayerUnitsModel,
+      ] as unknown as PlayerUnitsModel[];
+
+      const defenderPlayerRow = {
+        ...mockPlayerRow,
+        id: 'PLR-01JNY93XAW4D8Z4GHQ0T6EN8TN',
+        race: 'elf',
+        class: 'cleric',
+        attack_turns: 8,
+        experience: 0,
+        gold: 100,
+      } as unknown as PlayerRow;
+      const defenderUnits = [
+        {
+          unitType: 'guard_1',
+          quantity: 1,
+          calculateDefenceStrength: jest.fn().mockReturnValue(12),
+        } as unknown as PlayerUnitsModel,
+      ] as unknown as PlayerUnitsModel[];
+
+      const warHistoryCreate = jest.fn().mockResolvedValue({});
+      const mockCTX = {
+        modelFactory: {
+          warHistory: {
+            create: warHistoryCreate,
+          },
         },
+      } as unknown as Context;
+
+      const attacker = new PlayerModel(
+        mockCTX,
+        attackerPlayerRow,
+        attackerUnits,
+        [],
       );
+
+      const defender = new PlayerModel(
+        mockCTX,
+        defenderPlayerRow,
+        defenderUnits,
+        [],
+      );
+
+      attacker.save = jest.fn().mockResolvedValue(undefined);
+      defender.save = jest.fn().mockResolvedValue(undefined);
+
+      await attacker.attackPlayer(defender, 4);
+
+      expect(attacker.attackTurns).toEqual(6);
+      expect(attacker.experience).toEqual(0);
+      expect(attacker.save).toHaveBeenCalledTimes(1);
+      expect(defender.save).toHaveBeenCalledTimes(1);
+      expect(defender.experience).toBeGreaterThan(0);
+      expect(warHistoryCreate).toHaveBeenCalledWith(mockCTX, {
+        id: expect.any(String),
+        attacker_id: 'PLR-01JNY92QZMGD2B30S6PP0BBQ31',
+        defender_id: 'PLR-01JNY93XAW4D8Z4GHQ0T6EN8TN',
+        attack_turns_used: 4,
+        is_attacker_victor: false,
+        attacker_strength: 4,
+        defender_strength: 13,
+        gold_stolen: 0,
+        created_at: expect.any(Date),
+        attacker_experience: 0,
+        defender_experience: expect.any(Number),
+      });
     });
   });
 

--- a/apps/web-app/AGENTS.md
+++ b/apps/web-app/AGENTS.md
@@ -3,3 +3,4 @@
 - Authenticated player state in `DarkThroneClient` is a snapshot loaded from `/auth/current-user`; turn-based resources like `gold` and `attackTurns` will look stale unless the app re-fetches after the half-hour turn boundary or when the window regains focus.
 - Shared turn countdown and turn-refresh math lives in `apps/web-app/src/libs/turnTiming.ts`. Reuse it instead of duplicating half-hour calculations in components.
 - `App` owns global player refresh behavior. Prefer emitting `playerUpdate` after player-mutating actions and let the app shell re-fetch the canonical player snapshot.
+- Attacks mutate the authenticated player even on defeat, so `apps/web-app/src/pages/main/battle/attack/attackPlayer.tsx` should emit `playerUpdate` after any successful `/attack` response, not only victories.

--- a/apps/web-app/jest.config.ts
+++ b/apps/web-app/jest.config.ts
@@ -1,7 +1,7 @@
-/* eslint-disable */
 export default {
   displayName: 'web-app',
   preset: '../../jest.preset.js',
+  setupFiles: ['<rootDir>/test/setup.ts'],
   transform: {
     '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
     '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/react/babel'] }],

--- a/apps/web-app/src/pages/main/battle/attack/attackPlayer.spec.tsx
+++ b/apps/web-app/src/pages/main/battle/attack/attackPlayer.spec.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type DarkThroneClient from '@darkthrone/client-library';
+import type {
+  AuthedPlayerObject,
+  PlayerObject,
+  WarHistoryObject,
+} from '@darkthrone/interfaces';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
+import AttackPlayerPage from './attackPlayer';
+
+const targetPlayer: PlayerObject = {
+  id: 'PLR-target',
+  name: 'Target Player',
+  race: 'elf',
+  class: 'cleric',
+  gold: 500,
+  level: 12,
+  overallRank: 3,
+  armySize: 20,
+};
+
+const authenticatedPlayer: AuthedPlayerObject = {
+  id: 'PLR-attacker',
+  name: 'Attacker',
+  race: 'human',
+  class: 'fighter',
+  gold: 1000,
+  level: 12,
+  overallRank: 1,
+  armySize: 25,
+  attackStrength: 150,
+  defenceStrength: 120,
+  experience: 200,
+  attackTurns: 7,
+  goldInBank: 0,
+  citizensPerDay: 25,
+  depositHistory: [],
+  units: [],
+  items: [],
+  structureUpgrades: {
+    fortification: 0,
+    housing: 0,
+    armoury: 0,
+  },
+  goldPerTurn: 100,
+};
+
+function WarHistoryPage() {
+  const { historyID } = useParams<{ historyID: string }>();
+
+  return <div>War history {historyID}</div>;
+}
+
+function renderAttackPage(client: DarkThroneClient) {
+  render(
+    <MemoryRouter initialEntries={['/attack/PLR-target']}>
+      <Routes>
+        <Route
+          path="/attack/:playerID"
+          element={<AttackPlayerPage client={client} />}
+        />
+        <Route path="/war-history/:historyID" element={<WarHistoryPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function buildClient(isAttackerVictor: boolean) {
+  const fetchByID = jest.fn().mockResolvedValue(targetPlayer);
+  const attackPlayer = jest.fn().mockResolvedValue({
+    id: 'WRH-01',
+    attackerID: authenticatedPlayer.id,
+    defenderID: targetPlayer.id,
+    isAttackerVictor,
+    attackTurnsUsed: 1,
+    attackerStrength: 150,
+    defenderStrength: 120,
+    goldStolen: isAttackerVictor ? 50 : 0,
+    createdAt: new Date(),
+  } as WarHistoryObject);
+  const emit = jest.fn();
+
+  const client = {
+    players: { fetchByID },
+    attack: { attackPlayer },
+    authenticatedPlayer,
+    emit,
+  } as unknown as DarkThroneClient;
+
+  return { attackPlayer, client, emit, fetchByID };
+}
+
+describe('AttackPlayerPage', () => {
+  it.each([
+    { isAttackerVictor: true, outcome: 'victory' },
+    { isAttackerVictor: false, outcome: 'defeat' },
+  ])(
+    'emits playerUpdate and navigates after a successful $outcome',
+    async ({ isAttackerVictor }) => {
+      const { attackPlayer, client, emit, fetchByID } =
+        buildClient(isAttackerVictor);
+
+      renderAttackPage(client);
+
+      expect(await screen.findByText(targetPlayer.name)).toBeTruthy();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Attack' }));
+
+      expect(await screen.findByText('War history WRH-01')).toBeTruthy();
+      expect(fetchByID).toHaveBeenCalledWith(targetPlayer.id);
+      expect(attackPlayer).toHaveBeenCalledWith(targetPlayer.id, 1);
+      expect(emit).toHaveBeenCalledWith('playerUpdate');
+    },
+  );
+});

--- a/apps/web-app/src/pages/main/battle/attack/attackPlayer.tsx
+++ b/apps/web-app/src/pages/main/battle/attack/attackPlayer.tsx
@@ -83,9 +83,7 @@ export default function AttackPlayerPage(props: AttackPlayerPageProps) {
         attackTurns,
       );
 
-      if (attackResponse.isAttackerVictor) {
-        props.client.emit('playerUpdate');
-      }
+      props.client.emit('playerUpdate');
 
       navigate(`/war-history/${attackResponse.id}`);
     } catch (error) {

--- a/apps/web-app/test/setup.ts
+++ b/apps/web-app/test/setup.ts
@@ -1,0 +1,3 @@
+import { TextDecoder, TextEncoder } from 'node:util';
+
+Object.assign(globalThis, { TextDecoder, TextEncoder });


### PR DESCRIPTION
## Summary
- deduct attack turns for every completed attack outcome and await both player saves before returning the battle result
- emit `playerUpdate` after any successful attack response so the attacker snapshot refreshes on wins and losses
- add backend and frontend regression coverage for both attack outcomes, plus web-app Jest setup for `TextEncoder`

## Testing
- npx nx test api --runInBand
- npx nx test web-app --runInBand
- npx nx lint api
- npx nx lint web-app

Closes #102