### PR TITLE
Fix #106 create-player validation state and inline errors

### DIFF
--- a/apps/web-app/AGENTS.md
+++ b/apps/web-app/AGENTS.md
@@ -6,3 +6,4 @@
 - Overview XP progress should be calculated within the current level band. Reuse `apps/web-app/src/libs/experienceProgress.ts` instead of dividing lifetime XP by the next threshold in UI components.
 - API mutations in player-facing forms should catch structured `{ errors: [...] }` responses and render them inline. Reuse `apps/web-app/src/libs/apiErrors.ts` and `apps/web-app/src/components/inlineErrorAlert.tsx` instead of re-implementing ad hoc parsing/UI per screen.
 - Attacks mutate the authenticated player even on defeat, so `apps/web-app/src/pages/main/battle/attack/attackPlayer.tsx` should emit `playerUpdate` after any successful `/attack` response, not only victories.
+- Create-player name validation must stay tied to the exact string that was validated. When the input changes, stale validation results must not keep the submit button enabled or suppress inline create errors for the current value.

--- a/apps/web-app/src/pages/playerSelect/create.spec.tsx
+++ b/apps/web-app/src/pages/playerSelect/create.spec.tsx
@@ -1,0 +1,108 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type DarkThroneClient from '@darkthrone/client-library';
+import type {
+  PlayerClass,
+  PlayerNameValidation,
+  PlayerObject,
+  PlayerRace,
+} from '@darkthrone/interfaces';
+
+import CreatePlayerPage from './create';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+type MockPlayersClient = {
+  validatePlayerName: jest.Mock<Promise<PlayerNameValidation>, [string]>;
+  create: jest.Mock<Promise<PlayerObject>, [string, PlayerRace, PlayerClass]>;
+};
+
+function makeClient(players: MockPlayersClient): DarkThroneClient {
+  return {
+    players,
+  } as unknown as DarkThroneClient;
+}
+
+function fillRequiredSelections() {
+  fireEvent.click(screen.getByRole('button', { name: /human/i }));
+  fireEvent.click(screen.getByRole('button', { name: /fighter/i }));
+}
+
+describe('CreatePlayerPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  it('disables submit when the player name changes after a successful validation', async () => {
+    const players = {
+      validatePlayerName: jest.fn().mockResolvedValue({
+        isValid: true,
+        issues: [],
+      }),
+      create: jest.fn(),
+    };
+
+    render(<CreatePlayerPage client={makeClient(players)} />);
+
+    const playerNameInput = screen.getByLabelText('Player Name');
+    const submitButton = screen.getByRole('button', { name: /create player/i });
+
+    fillRequiredSelections();
+
+    fireEvent.change(playerNameInput, { target: { value: 'ValidName' } });
+    fireEvent.blur(playerNameInput);
+
+    await waitFor(() => {
+      expect(submitButton.disabled).toBe(false);
+    });
+
+    fireEvent.change(playerNameInput, { target: { value: 'TakenName' } });
+
+    expect(submitButton.disabled).toBe(true);
+    expect(players.validatePlayerName).toHaveBeenCalledWith('ValidName');
+  });
+
+  it('renders create-player validation failures inline and keeps the user on the form', async () => {
+    const players = {
+      validatePlayerName: jest.fn().mockResolvedValue({
+        isValid: true,
+        issues: [],
+      }),
+      create: jest.fn().mockRejectedValue({
+        errors: ['player.name.validation.taken'],
+      }),
+    };
+
+    render(<CreatePlayerPage client={makeClient(players)} />);
+
+    const playerNameInput = screen.getByLabelText('Player Name');
+    const submitButton = screen.getByRole('button', { name: /create player/i });
+
+    fillRequiredSelections();
+
+    fireEvent.change(playerNameInput, { target: { value: 'TakenName' } });
+    fireEvent.blur(playerNameInput);
+
+    await waitFor(() => {
+      expect(submitButton.disabled).toBe(false);
+    });
+
+    fireEvent.click(submitButton);
+
+    expect(players.create).toHaveBeenCalledWith(
+      'TakenName',
+      'human',
+      'fighter',
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('This name is already taken.')).toBeTruthy();
+    });
+
+    expect(submitButton.disabled).toBe(true);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web-app/src/pages/playerSelect/create.tsx
+++ b/apps/web-app/src/pages/playerSelect/create.tsx
@@ -1,8 +1,13 @@
 import DarkThroneClient from '@darkthrone/client-library';
 import { Logo } from '@darkthrone/react-components';
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from '@darkthrone/shadcnui/alert';
 import { Input } from '@darkthrone/shadcnui/input';
 import { Button } from '@darkthrone/shadcnui/button';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import RaceCard, { RaceCardProps } from './components/raceCard';
 import ClassCard, { ClassCardProps } from './components/classCard';
 import { useNavigate } from 'react-router-dom';
@@ -10,16 +15,41 @@ import {
   ExtractErrorCodesForStatuses,
   PlayerClass,
   PlayerRace,
+  POST_createPlayer,
   POST_validatePlayerName,
 } from '@darkthrone/interfaces';
 import { Field, FieldError, FieldLabel } from '@darkthrone/shadcnui/field';
 import { Label } from '@darkthrone/shadcnui/label';
-import { ArrowLeft } from 'lucide-react';
+import { AlertCircleIcon, ArrowLeft } from 'lucide-react';
 
-type PossibleErrorCodes = ExtractErrorCodesForStatuses<
+type PlayerNameValidationErrorCode = ExtractErrorCodesForStatuses<
   POST_validatePlayerName,
   400
 >;
+type PossibleErrorCodes =
+  | ExtractErrorCodesForStatuses<POST_validatePlayerName, 400 | 500>
+  | ExtractErrorCodesForStatuses<POST_createPlayer, 400 | 500>;
+
+interface PlayerNameStatus {
+  validatedName: string;
+  isValid: boolean;
+  messages: PossibleErrorCodes[];
+}
+
+function isAPIError(error: unknown): error is { errors: PossibleErrorCodes[] } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'errors' in error &&
+    Array.isArray((error as { errors?: unknown }).errors)
+  );
+}
+
+function isPlayerNameValidationError(
+  errorCode: PossibleErrorCodes,
+): errorCode is PlayerNameValidationErrorCode {
+  return errorCode.startsWith('player.name.validation.');
+}
 
 interface CreatePlayerPageProps {
   client: DarkThroneClient;
@@ -33,17 +63,19 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
     'player.name.validation.invalidCharacters':
       'Player name must only contain letters, numbers and underscores',
     'player.name.validation.tooShort':
-      'Player name must be longer than 3 characters',
+      'Player name must be at least 3 characters long',
     'player.name.validation.tooLong':
-      'Player name cannot be lonmger than 20 characters',
+      'Player name cannot be longer than 20 characters',
+    'server.error': 'An unexpected server error occurred. Please try again.',
   };
-
-  const [isFormValid, setIsFormValid] = useState<boolean>(false);
 
   const [playerName, setPlayerName] = useState<string>('');
   const [playerNameStatus, setPlayerNameStatus] = useState<
-    { isValid: boolean; messages: PossibleErrorCodes[] } | undefined
+    PlayerNameStatus | undefined
   >();
+  const [formErrorMessages, setFormErrorMessages] = useState<
+    PossibleErrorCodes[]
+  >([]);
 
   const [selectedRace, setSelectedRace] = useState<PlayerRace | undefined>(
     undefined,
@@ -52,17 +84,21 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
     undefined,
   );
 
-  useEffect(() => {
-    setIsFormValid(
-      playerNameStatus?.isValid === true &&
-        selectedRace !== undefined &&
-        selectedClass !== undefined,
-    );
-  }, [playerNameStatus, selectedRace, selectedClass]);
+  const currentPlayerNameStatus =
+    playerNameStatus?.validatedName === playerName
+      ? playerNameStatus
+      : undefined;
+  const isFormValid =
+    currentPlayerNameStatus?.isValid === true &&
+    selectedRace !== undefined &&
+    selectedClass !== undefined;
 
-  async function validatePlayerName() {
-    if (playerName.length === 0) {
+  async function validatePlayerName(nameToValidate: string) {
+    setFormErrorMessages([]);
+
+    if (nameToValidate.length === 0) {
       setPlayerNameStatus({
+        validatedName: nameToValidate,
         isValid: false,
         messages: ['player.name.validation.empty'],
       });
@@ -71,26 +107,19 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
 
     try {
       const response =
-        await props.client.players.validatePlayerName(playerName);
+        await props.client.players.validatePlayerName(nameToValidate);
 
       setPlayerNameStatus({
+        validatedName: nameToValidate,
         isValid: response.isValid,
         messages: response.issues,
       });
     } catch (error) {
-      if (
-        typeof error === 'object' &&
-        error !== null &&
-        'errors' in error &&
-        Array.isArray((error as { errors?: unknown }).errors)
-      ) {
-        setPlayerNameStatus({
-          isValid: false,
-          messages: (error as { errors?: PossibleErrorCodes[] })
-            .errors as PossibleErrorCodes[],
-        });
-      }
-      console.error('Error validating player name:', error);
+      setPlayerNameStatus({
+        validatedName: nameToValidate,
+        isValid: false,
+        messages: isAPIError(error) ? error.errors : ['server.error'],
+      });
     }
   }
 
@@ -186,11 +215,44 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
 
   async function handleCreatePlayer(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    if (!playerName || !selectedRace || !selectedClass) return;
+    if (
+      !playerName ||
+      !selectedRace ||
+      !selectedClass ||
+      currentPlayerNameStatus?.isValid !== true
+    ) {
+      return;
+    }
 
-    await props.client.players.create(playerName, selectedRace, selectedClass);
+    try {
+      setFormErrorMessages([]);
+      await props.client.players.create(
+        playerName,
+        selectedRace,
+        selectedClass,
+      );
 
-    navigate('/player-select');
+      navigate('/player-select');
+    } catch (error) {
+      const errorMessages = isAPIError(error) ? error.errors : ['server.error'];
+      const validationMessages = errorMessages.filter(
+        isPlayerNameValidationError,
+      );
+
+      if (validationMessages.length > 0) {
+        setPlayerNameStatus({
+          validatedName: playerName,
+          isValid: false,
+          messages: validationMessages,
+        });
+      }
+
+      setFormErrorMessages(
+        errorMessages.filter(
+          (message) => !isPlayerNameValidationError(message),
+        ),
+      );
+    }
   }
 
   function handleCancel() {
@@ -219,9 +281,25 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
       <div className="sm:mx-auto sm:w-full sm:max-w-120">
         <div className="bg-muted sm:rounded-lg px-6 py-12 sm:px-12">
           <form className="space-y-12" onSubmit={handleCreatePlayer}>
+            {formErrorMessages.length > 0 ? (
+              <Alert variant="destructive" className="text-sm [&>svg]:size-4">
+                <AlertCircleIcon />
+                <AlertTitle>There was a problem</AlertTitle>
+                <AlertDescription>
+                  <ul className="list-inside list-disc text-sm">
+                    {formErrorMessages.map((code) => (
+                      <li key={code}>{errorTranslations[code]}</li>
+                    ))}
+                  </ul>
+                </AlertDescription>
+              </Alert>
+            ) : null}
+
             <Field
               data-invalid={
-                playerNameStatus ? !playerNameStatus.isValid : undefined
+                currentPlayerNameStatus
+                  ? !currentPlayerNameStatus.isValid
+                  : undefined
               }
             >
               <FieldLabel htmlFor="playerName">Player Name</FieldLabel>
@@ -230,15 +308,20 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
                 type="text"
                 required
                 value={playerName}
-                onChange={(e) => setPlayerName(e.target.value)}
-                onBlur={() => validatePlayerName()}
+                onChange={(e) => {
+                  setPlayerName(e.target.value);
+                  setFormErrorMessages([]);
+                }}
+                onBlur={() => validatePlayerName(playerName)}
                 aria-invalid={
-                  playerNameStatus ? !playerNameStatus.isValid : undefined
+                  currentPlayerNameStatus
+                    ? !currentPlayerNameStatus.isValid
+                    : undefined
                 }
               />
-              {playerNameStatus && !playerNameStatus.isValid ? (
+              {currentPlayerNameStatus && !currentPlayerNameStatus.isValid ? (
                 <FieldError>
-                  {playerNameStatus.messages
+                  {currentPlayerNameStatus.messages
                     .map((err) => errorTranslations[err])
                     .join(', ')}
                 </FieldError>


### PR DESCRIPTION
## Summary
- tie player-name validation results to the exact name that was validated so stale success states do not keep submit enabled after edits
- surface create-player validation failures inline on the form and keep submit disabled until the current name is validated again
- add a focused create-player page spec for the stale-validation and inline-error regressions, and clear the existing web-app lint blockers

## Testing
- npx nx test web-app --runTestsByPath apps/web-app/src/pages/playerSelect/create.spec.tsx --runInBand
- npx nx lint web-app

Closes #106