### PR TITLE
Fix #110: avoid bank history state mutation during render

### DIFF
--- a/apps/web-app/AGENTS.md
+++ b/apps/web-app/AGENTS.md
@@ -1,5 +1,6 @@
 # Web App Notes
 
 - Authenticated player state in `DarkThroneClient` is a snapshot loaded from `/auth/current-user`; turn-based resources like `gold` and `attackTurns` will look stale unless the app re-fetches after the half-hour turn boundary or when the window regains focus.
+- Treat arrays on `client.authenticatedPlayer` as immutable snapshot data inside render paths. Copy before using mutating helpers like `.sort()`, `.reverse()`, or `.splice()`, and memoize derived collections when the work would otherwise repeat every render.
 - Shared turn countdown and turn-refresh math lives in `apps/web-app/src/libs/turnTiming.ts`. Reuse it instead of duplicating half-hour calculations in components.
 - `App` owns global player refresh behavior. Prefer emitting `playerUpdate` after player-mutating actions and let the app shell re-fetch the canonical player snapshot.

--- a/apps/web-app/src/pages/main/structures/bank/history.spec.tsx
+++ b/apps/web-app/src/pages/main/structures/bank/history.spec.tsx
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+
+import { render, screen, within } from '@testing-library/react';
+import type DarkThroneClient from '@darkthrone/client-library';
+import type { DepositHistory } from '@darkthrone/interfaces';
+import { TextDecoder, TextEncoder } from 'node:util';
+import type { ComponentType } from 'react';
+import type { MemoryRouterProps } from 'react-router-dom';
+
+globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
+globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;
+
+let MemoryRouter: ComponentType<MemoryRouterProps>;
+let BankHistoryPage: ComponentType<{ client: DarkThroneClient }>;
+
+function createClient(depositHistory: DepositHistory[]) {
+  return {
+    authenticatedPlayer: {
+      depositHistory,
+    },
+  } as DarkThroneClient;
+}
+
+describe('BankHistoryPage', () => {
+  beforeAll(async () => {
+    ({ MemoryRouter } = await import('react-router-dom'));
+    ({ default: BankHistoryPage } = await import('./history'));
+  });
+
+  it('renders a sorted copy without mutating deposit history', () => {
+    const depositHistory: DepositHistory[] = [
+      {
+        amount: 125,
+        date: new Date('2026-03-14T09:00:00.000Z'),
+        type: 'deposit',
+      },
+      {
+        amount: 25,
+        date: new Date('2026-03-12T09:00:00.000Z'),
+        type: 'withdraw',
+      },
+      {
+        amount: 500,
+        date: new Date('2026-03-15T09:00:00.000Z'),
+        type: 'deposit',
+      },
+    ];
+    const originalOrder = depositHistory.map(({ amount }) => amount);
+
+    render(
+      <MemoryRouter initialEntries={['/bank/history']}>
+        <BankHistoryPage client={createClient(depositHistory)} />
+      </MemoryRouter>,
+    );
+
+    const renderedAmounts = screen
+      .getAllByRole('row')
+      .slice(1)
+      .map((row) => within(row).getAllByRole('cell')[1]?.textContent?.trim());
+
+    expect(renderedAmounts).toEqual(['500', '125', '25']);
+    expect(depositHistory.map(({ amount }) => amount)).toEqual(originalOrder);
+  });
+});

--- a/apps/web-app/src/pages/main/structures/bank/history.tsx
+++ b/apps/web-app/src/pages/main/structures/bank/history.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import DarkThroneClient from '@darkthrone/client-library';
 import BankNavigation from './components/bankNavigation';
 
@@ -6,6 +7,14 @@ interface BankDepositPageProps {
 }
 export default function BankHistoryPage(props: BankDepositPageProps) {
   if (!props.client.authenticatedPlayer) return null;
+
+  const sortedDepositHistory = useMemo(
+    () =>
+      [...props.client.authenticatedPlayer.depositHistory].sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+      ),
+    [props.client.authenticatedPlayer.depositHistory],
+  );
 
   return (
     <main>
@@ -40,34 +49,28 @@ export default function BankHistoryPage(props: BankDepositPageProps) {
                     </tr>
                   </thead>
                   <tbody>
-                    {props.client.authenticatedPlayer.depositHistory
-                      .sort(
-                        (a, b) =>
-                          new Date(b.date).getTime() -
-                          new Date(a.date).getTime(),
-                      )
-                      .map((history, historyIdx) => (
-                        <tr key={historyIdx} className="hover:bg-accent/50">
-                          <td className="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium border-b text-foreground/75">
-                            <span className="block sm:hidden">
-                              {new Intl.DateTimeFormat(undefined, {
-                                dateStyle: 'short',
-                              }).format(new Date(history.date))}
-                            </span>
-                            <span className="hidden sm:block">
-                              {new Date(history.date).toLocaleString()}
-                            </span>
-                          </td>
-                          <td className="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium border-b text-right text-foreground/75">
-                            {new Intl.NumberFormat().format(history.amount)}
-                          </td>
-                          <td className="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium border-b text-foreground/75">
-                            {history.type === 'deposit'
-                              ? 'Deposit'
-                              : 'Withdrawal'}
-                          </td>
-                        </tr>
-                      ))}
+                    {sortedDepositHistory.map((history, historyIdx) => (
+                      <tr key={historyIdx} className="hover:bg-accent/50">
+                        <td className="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium border-b text-foreground/75">
+                          <span className="block sm:hidden">
+                            {new Intl.DateTimeFormat(undefined, {
+                              dateStyle: 'short',
+                            }).format(new Date(history.date))}
+                          </span>
+                          <span className="hidden sm:block">
+                            {new Date(history.date).toLocaleString()}
+                          </span>
+                        </td>
+                        <td className="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium border-b text-right text-foreground/75">
+                          {new Intl.NumberFormat().format(history.amount)}
+                        </td>
+                        <td className="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-medium border-b text-foreground/75">
+                          {history.type === 'deposit'
+                            ? 'Deposit'
+                            : 'Withdrawal'}
+                        </td>
+                      </tr>
+                    ))}
                   </tbody>
                 </table>
               </div>


### PR DESCRIPTION
## Summary
- memoize a sorted copy of `authenticatedPlayer.depositHistory` in the bank history page
- keep the authenticated player snapshot immutable during render
- add a regression spec covering render order and non-mutation

## Testing
- `npx nx test web-app --runTestsByPath apps/web-app/src/pages/main/structures/bank/history.spec.tsx`
- `npx eslint apps/web-app/src/pages/main/structures/bank/history.tsx apps/web-app/src/pages/main/structures/bank/history.spec.tsx`

Closes #110