### PR TITLE
fix: align auth and validation contracts

### DIFF
--- a/apps/api/src/models/player.ts
+++ b/apps/api/src/models/player.ts
@@ -605,6 +605,13 @@ export default class PlayerModel {
   ): Promise<PlayerNameValidation> {
     const errors: PlayerNameValidationIssue[] = [];
 
+    if (displayName.trim().length === 0) {
+      return {
+        isValid: false,
+        issues: ['player.name.validation.empty'],
+      };
+    }
+
     const existingPlayer = await ctx.modelFactory.player.fetchByDisplayName(
       ctx,
       displayName,

--- a/apps/api/test/acceptance/player/POST_validatePlayerName.spec.ts
+++ b/apps/api/test/acceptance/player/POST_validatePlayerName.spec.ts
@@ -1,0 +1,56 @@
+import request from 'supertest';
+import makeApplication from '../helpers/makeApplication';
+import DaoFactory from '../../../src/daoFactory';
+
+describe('POST_validatePlayerName', () => {
+  it('should return 400 if the display name is empty', async () => {
+    const fetchByDisplayName = jest.fn();
+    const { application } = makeApplication({
+      daoFactory: {
+        player: {
+          fetchByDisplayName,
+        },
+      } as unknown as DaoFactory,
+      authenticatedUser: {
+        user: {},
+        session: {},
+      },
+    });
+
+    const response = await request(application)
+      .post('/players/validate-name')
+      .set('Authorization', 'Bearer TOKEN')
+      .send({ displayName: '' });
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      errors: ['player.name.validation.empty'],
+    });
+    expect(fetchByDisplayName).not.toHaveBeenCalled();
+  });
+
+  it('should return 200 when the display name passes validation', async () => {
+    const { application } = makeApplication({
+      daoFactory: {
+        player: {
+          fetchByDisplayName: jest.fn().mockResolvedValue(null),
+        },
+      } as unknown as DaoFactory,
+      authenticatedUser: {
+        user: {},
+        session: {},
+      },
+    });
+
+    const response = await request(application)
+      .post('/players/validate-name')
+      .set('Authorization', 'Bearer TOKEN')
+      .send({ displayName: 'Valid_Name_7' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      isValid: true,
+      issues: [],
+    });
+  });
+});

--- a/apps/web-app/AGENTS.md
+++ b/apps/web-app/AGENTS.md
@@ -3,3 +3,4 @@
 - Authenticated player state in `DarkThroneClient` is a snapshot loaded from `/auth/current-user`; turn-based resources like `gold` and `attackTurns` will look stale unless the app re-fetches after the half-hour turn boundary or when the window regains focus.
 - Shared turn countdown and turn-refresh math lives in `apps/web-app/src/libs/turnTiming.ts`. Reuse it instead of duplicating half-hour calculations in components.
 - `App` owns global player refresh behavior. Prefer emitting `playerUpdate` after player-mutating actions and let the app shell re-fetch the canonical player snapshot.
+- Client auth events are typed contracts now: `userLogin` emits a `UserSessionObject`, while `playerChange` emits the current `{ user, player? }` snapshot. Consume those shapes directly instead of casting event payloads from `unknown`.

--- a/apps/web-app/src/app.tsx
+++ b/apps/web-app/src/app.tsx
@@ -17,7 +17,7 @@ import WarHistoryView from './pages/main/battle/warHistory/viewHistory';
 import ListWarHistory from './pages/main/battle/warHistory/listHistory';
 import TrainingScreen from './pages/main/battle/training';
 import NewsPage from './pages/main/home/news';
-import { UserSessionObject } from '@darkthrone/interfaces';
+import { CurrentUserState, UserSessionObject } from '@darkthrone/interfaces';
 import environment from './environments/environment';
 import BankDepositPage from './pages/main/structures/bank/deposit';
 import BankHistoryPage from './pages/main/structures/bank/history';
@@ -175,15 +175,12 @@ export function App() {
   }
 
   useEffect(() => {
-    const handleUserLogin = (user: unknown) => {
-      setCurrentUser(user as UserSessionObject);
-    };
+    const handleUserLogin = (user: UserSessionObject) => setCurrentUser(user);
     const handleUserLogout = () => {
       setCurrentUser(null);
     };
-    const handlePlayerChange = (user: unknown) => {
-      setCurrentUser(user as UserSessionObject);
-    };
+    const handlePlayerChange = ({ user }: CurrentUserState) =>
+      setCurrentUser(user);
     const handlePlayerUpdate = () => {
       void fetchCurrentUser();
     };

--- a/apps/web-app/src/pages/auth/register.tsx
+++ b/apps/web-app/src/pages/auth/register.tsx
@@ -30,6 +30,9 @@ import {
 } from '@darkthrone/interfaces';
 
 type PossibleErrorCodes = ExtractErrorCodesForStatuses<POST_register>;
+type RegisterPageErrorCode =
+  | PossibleErrorCodes
+  | 'auth.register.passwordsDoNotMatch';
 
 interface RegisterPageProps {
   client: DarkThroneClient;
@@ -37,9 +40,8 @@ interface RegisterPageProps {
 export default function RegisterPage(props: RegisterPageProps) {
   const navigate = useNavigate();
 
-  const errorTranslations: Record<PossibleErrorCodes, string> = {
+  const errorTranslations: Record<RegisterPageErrorCode, string> = {
     'auth.register.missingParams': 'Please provide both email and password.',
-    'auth.register.invalidParams': 'Please provide both email and password.',
     'auth.register.invalidPassword':
       'Password must be at least 7 characters long and include both upper and lower case letters.',
     'auth.register.passwordsDoNotMatch': 'Passwords do not match.',
@@ -51,7 +53,9 @@ export default function RegisterPage(props: RegisterPageProps) {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
 
-  const [errorMessages, setErrorMessages] = useState<PossibleErrorCodes[]>([]);
+  const [errorMessages, setErrorMessages] = useState<RegisterPageErrorCode[]>(
+    [],
+  );
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -77,7 +81,7 @@ export default function RegisterPage(props: RegisterPageProps) {
       ) {
         setErrorMessages(
           (error as { errors?: PossibleErrorCodes[] })
-            .errors as PossibleErrorCodes[],
+            .errors as RegisterPageErrorCode[],
         );
       } else {
         setErrorMessages(['server.error']);

--- a/apps/web-app/src/pages/playerSelect/create.tsx
+++ b/apps/web-app/src/pages/playerSelect/create.tsx
@@ -10,6 +10,7 @@ import {
   ExtractErrorCodesForStatuses,
   PlayerClass,
   PlayerRace,
+  PlayerNameValidation,
   POST_validatePlayerName,
 } from '@darkthrone/interfaces';
 import { Field, FieldError, FieldLabel } from '@darkthrone/shadcnui/field';
@@ -35,14 +36,14 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
     'player.name.validation.tooShort':
       'Player name must be longer than 3 characters',
     'player.name.validation.tooLong':
-      'Player name cannot be lonmger than 20 characters',
+      'Player name cannot be longer than 20 characters',
   };
 
   const [isFormValid, setIsFormValid] = useState<boolean>(false);
 
   const [playerName, setPlayerName] = useState<string>('');
   const [playerNameStatus, setPlayerNameStatus] = useState<
-    { isValid: boolean; messages: PossibleErrorCodes[] } | undefined
+    PlayerNameValidation | undefined
   >();
 
   const [selectedRace, setSelectedRace] = useState<PlayerRace | undefined>(
@@ -64,7 +65,7 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
     if (playerName.length === 0) {
       setPlayerNameStatus({
         isValid: false,
-        messages: ['player.name.validation.empty'],
+        issues: ['player.name.validation.empty'],
       });
       return;
     }
@@ -75,7 +76,7 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
 
       setPlayerNameStatus({
         isValid: response.isValid,
-        messages: response.issues,
+        issues: response.issues,
       });
     } catch (error) {
       if (
@@ -86,7 +87,7 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
       ) {
         setPlayerNameStatus({
           isValid: false,
-          messages: (error as { errors?: PossibleErrorCodes[] })
+          issues: (error as { errors?: PossibleErrorCodes[] })
             .errors as PossibleErrorCodes[],
         });
       }
@@ -238,7 +239,7 @@ export default function CreatePlayerPage(props: CreatePlayerPageProps) {
               />
               {playerNameStatus && !playerNameStatus.isValid ? (
                 <FieldError>
-                  {playerNameStatus.messages
+                  {playerNameStatus.issues
                     .map((err) => errorTranslations[err])
                     .join(', ')}
                 </FieldError>

--- a/libs/AGENTS.md
+++ b/libs/AGENTS.md
@@ -1,0 +1,5 @@
+# Libraries Notes
+
+- Shared interface error-code unions should only include codes the API actually emits. Keep client-only validation states local to the consuming UI.
+- `DarkThroneClient` auth events are part of the contract surface. `userLogin` emits a `UserSessionObject`, while `playerChange` and `updateCurrentUser` emit the current user/player snapshot shape from the shared interfaces.
+- Player-name validation should stay aligned end to end: if the UI needs an error code like `player.name.validation.empty`, the API model and shared interfaces must emit it too.

--- a/libs/client-library/src/daos/auth.ts
+++ b/libs/client-library/src/daos/auth.ts
@@ -33,7 +33,7 @@ export default class AuthDAO {
         requestBody,
       );
 
-      this.root.emit('userLogin', response.data);
+      this.root.emit('userLogin', response.data.session);
 
       /* TODO: Refactor this, the DAO shouldn't be changing root HTTP headers,
        * or setting local storage values.
@@ -64,7 +64,7 @@ export default class AuthDAO {
         POST_register['Responses'][201]
       >('/auth/register', requestBody);
 
-      this.root.emit('userLogin', response.data);
+      this.root.emit('userLogin', response.data.session);
 
       /* TODO: Refactor this, the DAO shouldn't be changing root HTTP headers,
        * or setting local storage values.
@@ -95,7 +95,7 @@ export default class AuthDAO {
       this.root.serverTime = new Date(response.data.user.serverTime);
       this.root.authenticatedUser = response.data.user;
       this.root.authenticatedPlayer = response.data.player;
-      this.root.emit('updateCurrentUser');
+      this.root.emit('updateCurrentUser', response.data);
 
       return response.data.user;
     } catch (error) {
@@ -135,7 +135,7 @@ export default class AuthDAO {
 
       this.root.authenticatedUser = response.data.user;
       this.root.authenticatedPlayer = response.data.player;
-      this.root.emit('playerChange', response.data.user);
+      this.root.emit('playerChange', response.data);
 
       return response.data.user;
     } catch (error) {
@@ -154,7 +154,7 @@ export default class AuthDAO {
 
       this.root.authenticatedUser = response.data.user;
       this.root.authenticatedPlayer = undefined;
-      this.root.emit('playerChange', response.data.user);
+      this.root.emit('playerChange', response.data);
 
       return response.data.user;
     } catch (error) {

--- a/libs/client-library/src/index.ts
+++ b/libs/client-library/src/index.ts
@@ -6,17 +6,31 @@ import WarHistoryController from './daos/warHistory';
 import TrainingDAO from './daos/training';
 import BankingDAO from './daos/banking';
 import type {
+  CurrentUserState,
   AuthedPlayerObject,
   UserSessionObject,
 } from '@darkthrone/interfaces';
 import StructuresDAO from './daos/structures';
 import ArmouryDAO from './daos/armoury';
 
-type EventListener = (...args: unknown[]) => void;
+export type DarkThroneClientEventMap = {
+  userLogin: [user: UserSessionObject];
+  userLogout: [];
+  updateCurrentUser: [state: CurrentUserState];
+  playerChange: [state: CurrentUserState];
+  playerUpdate: [];
+};
+
+type EventName = keyof DarkThroneClientEventMap;
+type EventListener<Event extends EventName> = (
+  ...args: DarkThroneClientEventMap[Event]
+) => void;
 
 export default class DarkThroneClient {
   public http: AxiosInstance;
-  public events: { [event: string]: EventListener[] } = {};
+  public events: Partial<{
+    [Event in EventName]: EventListener<Event>[];
+  }> = {};
 
   public authenticatedUser: UserSessionObject | undefined;
   public authenticatedPlayer: AuthedPlayerObject | undefined;
@@ -62,24 +76,37 @@ export default class DarkThroneClient {
     });
   }
 
-  on(event: string, listener: EventListener) {
-    if (!this.events[event]) {
-      this.events[event] = [];
+  on<Event extends EventName>(event: Event, listener: EventListener<Event>) {
+    const eventListeners = this.events[event] as
+      | EventListener<Event>[]
+      | undefined;
+
+    if (!eventListeners) {
+      this.events[event] = [listener] as (typeof this.events)[Event];
+      return;
     }
-    this.events[event].push(listener);
+
+    eventListeners.push(listener);
   }
 
-  off(event: string, listener: EventListener) {
-    const eventListeners = this.events[event];
+  off<Event extends EventName>(event: Event, listener: EventListener<Event>) {
+    const eventListeners = this.events[event] as
+      | EventListener<Event>[]
+      | undefined;
     if (!eventListeners) return;
 
     this.events[event] = eventListeners.filter(
       (registeredListener) => registeredListener !== listener,
-    );
+    ) as (typeof this.events)[Event];
   }
 
-  emit(event: string, ...args: unknown[]) {
-    const eventListeners = this.events[event];
+  emit<Event extends EventName>(
+    event: Event,
+    ...args: DarkThroneClientEventMap[Event]
+  ) {
+    const eventListeners = this.events[event] as
+      | EventListener<Event>[]
+      | undefined;
     if (eventListeners) {
       eventListeners.forEach((listener) => {
         listener(...args);

--- a/libs/interfaces/src/api/auth.ts
+++ b/libs/interfaces/src/api/auth.ts
@@ -2,6 +2,7 @@ import {
   API_Error,
   AuthedPlayerObject,
   AuthenticatedEndpointDefinition,
+  CurrentUserState,
   EndpointDefinition,
   ExtendEndpointDefinition,
   UserSessionObject,
@@ -34,10 +35,8 @@ export type POST_register = ExtendEndpointDefinition<
       201: ValidAuthResponse;
       400: API_Error<
         | 'auth.register.missingParams'
-        | 'auth.register.invalidParams'
         | 'auth.register.emailInUse'
         | 'auth.register.invalidPassword'
-        | 'auth.register.passwordsDoNotMatch'
       >;
     };
   }
@@ -47,10 +46,7 @@ export type GET_currentUser = ExtendEndpointDefinition<
   AuthenticatedEndpointDefinition,
   {
     Responses: {
-      200: {
-        user: UserSessionObject;
-        player: AuthedPlayerObject | undefined;
-      };
+      200: CurrentUserState;
     };
   }
 >;
@@ -86,10 +82,7 @@ export type POST_unassumePlayer = ExtendEndpointDefinition<
   AuthenticatedEndpointDefinition,
   {
     Responses: {
-      200: {
-        user: UserSessionObject;
-        player: null;
-      };
+      200: CurrentUserState;
     };
   }
 >;

--- a/libs/interfaces/src/index.ts
+++ b/libs/interfaces/src/index.ts
@@ -222,6 +222,11 @@ export type ValidAuthResponse = {
   token: string;
 };
 
+export type CurrentUserState = {
+  user: UserSessionObject;
+  player?: AuthedPlayerObject;
+};
+
 export type StructureUpgrade = {
   name: string;
   cost: number;


### PR DESCRIPTION
## Summary
- align shared auth contracts with the API responses the backend actually emits
- type `DarkThroneClient` auth events and update the web app to consume the real payload shapes
- make empty player-name validation part of the backend contract and cover it with an acceptance test

## Testing
- `npx jest --config apps/api/jest.config.ts --runInBand apps/api/test/acceptance/player/POST_validatePlayerName.spec.ts apps/api/test/acceptance/auth/GET_currentUser.spec.ts apps/api/test/acceptance/auth/POST_unassumePlayer.spec.ts apps/api/test/acceptance/auth/POST_register.spec.ts`
- `npx tsc -p libs/interfaces/tsconfig.lib.json --noEmit`
- `npx tsc -p libs/client-library/tsconfig.lib.json --noEmit`
- `npx tsc -p apps/web-app/tsconfig.app.json --noEmit`
- `npx tsc -p apps/api/tsconfig.app.json --noEmit`

Fixes #108
